### PR TITLE
Fix bug

### DIFF
--- a/custom_components/tianqi/__init__.py
+++ b/custom_components/tianqi/__init__.py
@@ -478,8 +478,19 @@ class TianqiClient:
 
     async def update_summary(self, **kwargs):
         api = self.api_url('weather_index/%s.html' % kwargs.get('area_id', self.area_id))
-        res = await self.http.get(api, allow_redirects=False, verify_ssl=False)
-        txt = await res.text()
+        txt = ''
+        try:
+            res = await self.http.get(api, allow_redirects=False, verify_ssl=False)
+            txt = await res.text()
+        except aiohttp.ClientConnectorError as e:
+            raise IntegrationError(f"无法连接到服务器(update_summary): {str(e)}")
+        # except aiohttp.ClientResponseError as e:
+        #     raise IntegrationError(f"服务器返回错误(update_summary): HTTP {e.status}")
+        except asyncio.TimeoutError:
+            raise IntegrationError("请求超时，请检查网络连接(update_summary)")
+        except Exception as e:
+            raise IntegrationError(f"网络请求失败(update_summary): {type(e).__name__}: {str(e)}")
+    
         if not txt:
             raise IntegrationError(f'Empty response from: {api}')
         if res.status != 200:
@@ -498,8 +509,19 @@ class TianqiClient:
 
     async def update_alarms(self, **kwargs):
         api = self.api_url('dingzhi/%s.html' % kwargs.get('area_id', self.area_id))
-        res = await self.http.get(api, allow_redirects=False, verify_ssl=False)
-        txt = await res.text()
+        txt = ''
+        try:
+            res = await self.http.get(api, allow_redirects=False, verify_ssl=False)
+            txt = await res.text()
+        except aiohttp.ClientConnectorError as e:
+            raise IntegrationError(f"无法连接到服务器(update_alarms): {str(e)}")
+        # except aiohttp.ClientResponseError as e:
+        #     raise IntegrationError(f"服务器返回错误(update_alarms): HTTP {e.status}")
+        except asyncio.TimeoutError:
+            raise IntegrationError("请求超时，请检查网络连接(update_alarms)")
+        except Exception as e:
+            raise IntegrationError(f"网络请求失败(update_alarms): {type(e).__name__}: {str(e)}")
+        
         if not txt:
             raise IntegrationError(f'Empty response from: {api}')
         if res.status != 200:
@@ -515,8 +537,19 @@ class TianqiClient:
 
     async def update_dailies(self, **kwargs):
         api = self.api_url('weixinfc/%s.html' % kwargs.get('area_id', self.area_id))
-        res = await self.http.get(api, allow_redirects=False, verify_ssl=False)
-        txt = await res.text()
+        txt = ''
+        try:
+            res = await self.http.get(api, allow_redirects=False, verify_ssl=False)
+            txt = await res.text()
+        except aiohttp.ClientConnectorError as e:
+            raise IntegrationError(f"无法连接到服务器(update_dailies): {str(e)}")
+        # except aiohttp.ClientResponseError as e:
+        #     raise IntegrationError(f"服务器返回错误(update_dailies): HTTP {e.status}")
+        except asyncio.TimeoutError:
+            raise IntegrationError("请求超时，请检查网络连接(update_dailies)")
+        except Exception as e:
+            raise IntegrationError(f"网络请求失败(update_dailies): {type(e).__name__}: {str(e)}")
+        
         if not txt:
             raise IntegrationError(f'Empty response from: {api}')
         if res.status != 200:
@@ -531,8 +564,19 @@ class TianqiClient:
 
     async def update_hourlies(self, **kwargs):
         api = self.api_url('wap_180h/%s.html' % kwargs.get('area_id', self.area_id))
-        res = await self.http.get(api, allow_redirects=False, verify_ssl=False)
-        txt = await res.text()
+        txt = ''
+        try:
+            res = await self.http.get(api, allow_redirects=False, verify_ssl=False)
+            txt = await res.text()
+        except aiohttp.ClientConnectorError as e:
+            raise IntegrationError(f"无法连接到服务器(update_hourlies): {str(e)}")
+        # except aiohttp.ClientResponseError as e:
+        #     raise IntegrationError(f"服务器返回错误(update_hourlies): HTTP {e.status}")
+        except asyncio.TimeoutError:
+            raise IntegrationError("请求超时，请检查网络连接(update_hourlies)")
+        except Exception as e:
+            raise IntegrationError(f"网络请求失败(update_hourlies): {type(e).__name__}: {str(e)}")
+        
         if not txt:
             raise IntegrationError(f'Empty response from: {api}')
         if res.status != 200:
@@ -547,12 +591,23 @@ class TianqiClient:
 
     async def update_minutely(self, **kwargs):
         api = self.api_url('webgis_rain_new/webgis/minute', 'd3')
+        txt = ''
         pms = {
             'lat': self.station.latitude,
             'lon': self.station.longitude,
         }
-        res = await self.http.get(api, params=pms, allow_redirects=False, verify_ssl=False)
-        txt = await res.text()
+        try:
+            res = await self.http.get(api, params=pms, allow_redirects=False, verify_ssl=False)
+            txt = await res.text()
+        except aiohttp.ClientConnectorError as e:
+            raise IntegrationError(f"无法连接到服务器(update_minutely): {str(e)}")
+        # except aiohttp.ClientResponseError as e:
+        #     raise IntegrationError(f"服务器返回错误(update_minutely): HTTP {e.status}")
+        except asyncio.TimeoutError:
+            raise IntegrationError("请求超时，请检查网络连接(update_minutely)")
+        except Exception as e:
+            raise IntegrationError(f"网络请求失败(update_minutely): {type(e).__name__}: {str(e)}")
+        
         if not txt:
             raise IntegrationError(f'Empty response from: {api} {pms}')
         if res.status != 200:
@@ -576,13 +631,13 @@ class TianqiClient:
             )
             txt = await res.text()
         except aiohttp.ClientConnectorError as e:
-            raise IntegrationError(f"无法连接到服务器: {str(e)}")
-        except aiohttp.ClientResponseError as e:
-            raise IntegrationError(f"服务器返回错误: HTTP {e.status}")
+            raise IntegrationError(f"无法连接到服务器(update_observe): {str(e)}")
+        # except aiohttp.ClientResponseError as e:
+        #     raise IntegrationError(f"服务器返回错误(update_observe): HTTP {e.status}")
         except asyncio.TimeoutError:
-            raise IntegrationError("请求超时，请检查网络连接")
+            raise IntegrationError("请求超时，请检查网络连接(update_observe)")
         except Exception as e:
-            raise IntegrationError(f"网络请求失败: {type(e).__name__}: {str(e)}")
+            raise IntegrationError(f"网络请求失败(update_observe): {type(e).__name__}: {str(e)}")
 
         fmt = '%Y%m%d%H%M'
         dat = {}

--- a/custom_components/tianqi/__init__.py
+++ b/custom_components/tianqi/__init__.py
@@ -179,7 +179,11 @@ class TianqiClient:
 
         self.http = aiohttp_client.async_create_clientsession(
             hass,
-            timeout=aiohttp.ClientTimeout(total=20),
+            timeout=aiohttp.ClientTimeout(
+                    total=20,
+                    sock_connect=5,  # 连接超时
+                    sock_read=15     # 读取超时
+                ),
             auto_cleanup=False,
         )
         self.http._default_headers = {


### PR DESCRIPTION
增加重试机制
修复dns报错信息 导致某些信息无法获取的问题 中国天气那边更换了接口域名导致
延长dns的刷新时间
增加请求的错误捕获 防止初始化时出错


关于警告 commit:ae11ef0e5708666175dc2f4739045a7acbb96863 [homeassistant.helpers.frame] Detected that custom integration 'tianqi' sets option flow config_entry explicitly, which is deprecated at custom_components/tianqi/config_flow.py, line 92: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12
这个只需要注释掉custom_components/tianqi/config_flow.py, line 92的self.config_entry = config_entry 即可
```
class OptionsFlowHandler(config_entries.OptionsFlow):
    def __init__(self, config_entry: config_entries.ConfigEntry):
        """Initialize options flow."""
        #self.config_entry = config_entry
```
 因为ha的新版框架已经提供self.config_entry 因为可能会存在旧版本的兼容性问题 故pr不包含custom_components/tianqi/config_flow.py文件

我很早就修了这堆问题 但是忘了提交pr了 
<img width="1074" height="773" alt="image" src="https://github.com/user-attachments/assets/9f75c4cc-faf3-4838-98ad-318681513a72" />
