### PR TITLE
修复一个加载时候dns报错的问题

### DIFF
--- a/custom_components/tianqi/__init__.py
+++ b/custom_components/tianqi/__init__.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from datetime import datetime, timedelta
 from functools import wraps
 from typing import Callable, Set, Type, Tuple
-from aiohttp import ClientError, ClientResponseError
+from aiohttp import ClientError, ClientResponseError, ClientConnectorDNSError
 
 from homeassistant.const import (
     Platform,
@@ -196,7 +196,12 @@ def aiohttp_retry(
                     last_exception = exc
                     if attempt == max_retries:
                         break
+                        
                     is_retryable_status = False
+                    # DNS 错误和超时
+                    if isinstance(exc, ClientConnectorDNSError):
+                        is_retryable_status = True
+                    # HTTP 状态码错误
                     if isinstance(exc, ClientResponseError):
                         if exc.status in retry_on_status:
                             is_retryable_status = True


### PR DESCRIPTION
修复一个初始化加载时候dns报错的问题 导致无法更新实体数据的问题 
weather.com.cn以及其子域名在docker环境下 重启后初次解析概率会出现域名解析失败的问题 重新加载插件问题依旧 
检测docker环境中系统对weather.com.cn以及其子域名【ping/dig】解析均正常  
代码中增加重试后可解决 

我先前的pr应该是对整个网络请求进行了一个很暴力的判断重试
更新代码使用了aiohttp_retry之后又出现了 
检查了aiohttp_retry发现没有对dns异常进行处理
```
日志记录器: custom_components.tianqi
来源: custom_components/tianqi/__init__.py:193
集成: 天气预报 (文档, 问题)
首次出现: 23:43:59 (1 次出现)
上次记录: 23:43:59

Error while fetching data from update_alarms
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/aiohttp/resolver.py", line 117, in resolve
    resp = await self._resolver.getaddrinfo(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
aiodns.error.DNSError: (12, 'Timeout while contacting DNS servers')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1532, in _create_direct_connection
    hosts = await self._resolve_host(host, port, traces=traces)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1148, in _resolve_host
    return await asyncio.shield(resolved_host_task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1179, in _resolve_host_with_throttle
    addrs = await self._resolver.resolve(host, port, family=self._family)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp_asyncmdnsresolver/_impl.py", line 140, in resolve
    return await super().resolve(host, port, family)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/resolver.py", line 126, in resolve
    raise OSError(None, msg) from exc
OSError: [Errno None] Timeout while contacting DNS servers

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/config/custom_components/tianqi/__init__.py", line 193, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tianqi/__init__.py", line 564, in update_alarms
    res = await self.http.get(api, allow_redirects=False, verify_ssl=False)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client.py", line 770, in _request
    resp = await handler(req)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client.py", line 725, in _connect_and_send_request
    conn = await self._connector.connect(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        req, traces=traces, timeout=real_timeout
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 642, in connect
    proto = await self._create_connection(req, traces, timeout)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1209, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1538, in _create_direct_connection
    raise ClientConnectorDNSError(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorDNSError: Cannot connect to host d1.weather.com.cn:443 ssl:False [Timeout while contacting DNS servers]
```