### PR TITLE
Add indexes_short attribute

### DIFF
--- a/custom_components/tianqi/weather.py
+++ b/custom_components/tianqi/weather.py
@@ -132,6 +132,7 @@ class WeatherEntity(BaseEntity):
             ]}
 
         indexes = {}
+        indexes_short = {}
         for k, v in dataZS.items():
             if '_name' not in k:
                 continue
@@ -139,8 +140,12 @@ class WeatherEntity(BaseEntity):
             if not (des := dataZS.get(f'{key}_des_s')):
                 continue
             indexes[v] = des
+            if hint := dataZS.get(f'{key}_hint'):
+                indexes_short[v.removesuffix('指数')] = hint
         if indexes:
             self._attr_extra_state_attributes['indexes'] = indexes
+        if indexes_short:
+            self._attr_extra_state_attributes['indexes_short'] = indexes_short
 
         forecasts = await self.async_forecast_daily()
         if hasattr(self, '_attr_forecast'):


### PR DESCRIPTION
## Summary
- Add `indexes_short` attribute to expose brief values that are easier to read
- Non-breaking: existing `indexes` attribute unchanged

## Before / After

**Before** (indexes only):
```yaml
indexes:
  路况指数: 有降水，路面潮湿，请小心驾驶。
  感冒指数: 无明显降温，感冒几率较低。
```

**After** (new `indexes_short` added):
```yaml
indexes:
  路况指数: 有降水，路面潮湿，请小心驾驶。
  感冒指数: 无明显降温，感冒几率较低。
indexes_short:
  路况: 潮湿
  感冒: 少发
```