### PR TITLE
Sort alarms by severity

### DIFF
--- a/custom_components/tianqi/converters/base.py
+++ b/custom_components/tianqi/converters/base.py
@@ -119,8 +119,15 @@ class AlarmsBinarySensorConv(Converter):
         code = None
         titles = []
         alarms = []
-        for v in client.data.get(self.prop) or []:
-            code = f'{v.get("w4")}{v.get("w6")}'
+        raw_alarms = sorted(
+            client.data.get(self.prop) or [],
+            key=lambda v: v.get('w6', ''),
+            reverse=True,
+        )
+        for v in raw_alarms:
+            alarm_code = f'{v.get("w4")}{v.get("w6")}'
+            if code is None:
+                code = alarm_code
             title = v.get('w13', '')
             titles.append(re.sub(r'.+发布的?(.+预警)', r'\1', title))
             alarms.append({
@@ -128,12 +135,12 @@ class AlarmsBinarySensorConv(Converter):
                 'description': v.get('w9', ''),
                 'province': v.get('w1'),
                 'city': v.get('w2'),
-                'code': code,
+                'code': alarm_code,
                 'alertld': v.get('w16'),
                 'link': client.web_url('warning/publish_area.shtml?code=%s' % client.area_id),
             })
         payload['warning'] = len(alarms) > 0
-        payload['title'] = ', '.join(set(titles))
+        payload['title'] = ', '.join(dict.fromkeys(titles))
         payload['alarms'] = alarms
         src = client.web_url('m2/i/about/alarmpic/%s.gif' % code, 'www') if code else None
         self.option['entity_picture'] = f'https://cfrp.hacs.vip/{src}' if src else None

--- a/custom_components/tianqi/weather.py
+++ b/custom_components/tianqi/weather.py
@@ -132,6 +132,7 @@ class WeatherEntity(BaseEntity):
             ]}
 
         indexes = {}
+        indexes_short = {}
         for k, v in dataZS.items():
             if '_name' not in k:
                 continue
@@ -139,8 +140,12 @@ class WeatherEntity(BaseEntity):
             if not (des := dataZS.get(f'{key}_des_s')):
                 continue
             indexes[v] = des
+            if hint := dataZS.get(f'{key}_hint'):
+                indexes_short[v.removesuffix('指数')] = hint
         if indexes:
             self._attr_extra_state_attributes['indexes'] = indexes
+        if indexes_short:
+            self._attr_extra_state_attributes['indexes_short'] = indexes_short
 
         forecasts = await self.async_forecast_daily()
         if hasattr(self, '_attr_forecast'):


### PR DESCRIPTION
This PR improves alarm handling for the warning binary sensor by:

* Sorting alarms by severity in descending order (04 red > 03 orange > 02 yellow > 01 blue)
* Ensuring entity_picture uses the highest-severity alarm icon
* Deduplicating warning titles while preserving display order

Before:
```yaml
title: 暴雨蓝色预警信号, 大风蓝色预警信号, 雷电黄色预警信号
```
After:
```yaml
title: 雷电黄色预警信号, 暴雨蓝色预警信号, 大风蓝色预警信号
```